### PR TITLE
feat(main.go): add support for debugging with pprof

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,22 @@ THE SOFTWARE.
 */
 package main
 
-import "github.com/MohammadBnei/go-openai-cli/cmd"
+import (
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"strconv"
+
+	"github.com/MohammadBnei/go-openai-cli/cmd"
+)
 
 func main() {
+	debugStr := os.Getenv("DEBUG")
+	debug, _ := strconv.ParseBool(debugStr)
+	if debug {
+		go func() {
+			http.ListenAndServe(":1234", nil)
+		}()
+	}
 	cmd.Execute()
 }


### PR DESCRIPTION
feat(ui/prompt.go): add vim mode to prompt, add interrupt signal handling, remove tty dependency, add help text The main.go file now supports debugging with pprof by adding a listener on port 1234 when the DEBUG environment variable is set to true. The ui/prompt.go file now supports vim mode in the prompt and has added interrupt signal handling to cancel a prompt. The tty dependency has been removed, and help text has been added to the prompt.