### PR TITLE
dev

### DIFF
--- a/cmd/speech.go
+++ b/cmd/speech.go
@@ -28,6 +28,8 @@ var carriageReturnC []string
 var advancedFormating string
 var systemOptions []string
 var maxMinutes int
+var autoFilename string
+var autoMode bool
 
 // speechCmd represents the speech command
 var speechCmd = &cobra.Command{
@@ -105,6 +107,14 @@ var speechCmd = &cobra.Command{
 
 			fmt.Print("\n---\n", speech, "\n---\n\n")
 
+			if autoMode {
+				err := ui.AddToFile([]byte(speech), autoFilename)
+				if err != nil {
+					fmt.Println(err)
+				}
+				continue SpeechLoop
+			}
+
 			if lo.SomeBy[service.ChatMessage](service.GetMessages(), func(m service.ChatMessage) bool {
 				return m.Role == openai.ChatMessageRoleSystem
 			}) {
@@ -175,12 +185,15 @@ func init() {
 	rootCmd.AddCommand(speechCmd)
 
 	speechCmd.Flags().StringP("lang", "l", "en", "language")
-	speechCmd.Flags().StringArrayVarP(&carriageReturnC, "carriage-return", "n", []string{"carriage return"}, "The carriage return character.")
+	speechCmd.Flags().StringArrayVarP(&carriageReturnC, "carriage-return", "c", []string{"carriage return"}, "The carriage return character.")
 	speechCmd.Flags().BoolVarP(&format, "format", "f", false, "format the output with the carriage return character.")
 	speechCmd.Flags().StringVarP(&advancedFormating, "advanced-format", "a", "add markdown formating. Add a title and a table of content from the content of the speech, and add the coresponding subtitles. Do not modify the content of the speech", "Add advanced formating that will be sent as system command to openai")
 	speechCmd.Flags().BoolVarP(&markdownMode, "markdown", "m", false, "Format the output to markdown")
 	speechCmd.Flags().StringArrayVarP(&systemOptions, "system", "s", []string{}, "additionnal system options")
 	speechCmd.Flags().IntVarP(&maxMinutes, "max-minutes", "t", 4, "max record time (in minutes) (max : 4 minutes)")
+
+	speechCmd.Flags().StringVarP(&autoFilename, "filename", "n", time.Now().Format("2006-01-02_15:04:05")+".txt", "When in auto mode, the name of the file")
+	speechCmd.Flags().BoolVar(&autoMode, "auto", false, "Automatically save the speech to a file.")
 
 	// Here you will define your flags and configuration settings.
 

--- a/ui/file.go
+++ b/ui/file.go
@@ -134,6 +134,53 @@ FileLoop:
 	return nil
 }
 
+func AddToFile(content []byte, filename string) error {
+	if filename == "" {
+		filePrompt := promptui.Prompt{
+			Label: "specify a filename (with extension)",
+		}
+		var err error
+		filename, err = filePrompt.Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	if strings.Contains(filename, "/") {
+		splitted := strings.Split(filename, "/")
+		dw := strings.Join(splitted[:len(splitted)-1], "/")
+
+		if _, err := os.Stat(dw); errors.Is(err, os.ErrNotExist) {
+			err := os.MkdirAll(dw, os.ModePerm)
+			if err != nil {
+				fmt.Println(err)
+			}
+			fmt.Println("Created directory : " + dw)
+		}
+	}
+
+	content = append([]byte(time.Now().Format("15:04:05 --- \n")), content...)
+
+	if _, err := os.Stat(filename); err == nil {
+		fileContent, err := os.ReadFile(filename)
+		if err != nil {
+			return err
+		}
+		content = append([]byte("\n\n"), content...)
+		fmt.Println(fileContent)
+		content = append(fileContent, content...)
+	}
+
+	fmt.Println(string(content))
+
+	os.WriteFile(filename, content, os.ModePerm)
+
+	fmt.Println("saved to", filename)
+
+	return nil
+
+}
+
 func SaveToFile(content []byte, filename string) error {
 	if filename == "" {
 		filePrompt := promptui.Prompt{


### PR DESCRIPTION
- fix(terminal): removed clear screen command
- feat(speech.go): add support for auto saving speech to a file feat(file.go): add function to add content to a file The speech command now supports an auto mode, which automatically saves the speech output to a file. The filename can be specified using the --filename flag, and if not provided, the user will be prompted to enter a filename. The content is then appended to the file, with a timestamp added at the beginning. The file.go file now includes a new function AddToFile, which handles the logic of adding content to a file.
- chore(prompt.go): refactor help section and add support for command shortcuts feat(prompt.go): add banner message when quitting the prompt The help section has been refactored to improve readability and consistency. Command shortcuts have been added to allow users to use backslashes followed by the command name to execute a command. When quitting the prompt, a banner message is now displayed to provide a more pleasant user experience.
