### PR TITLE
dev

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -1,0 +1,64 @@
+//go:build portaudio
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/MohammadBnei/go-openai-cli/service"
+	"github.com/MohammadBnei/go-openai-cli/ui"
+	"github.com/atotto/clipboard"
+	"github.com/spf13/cobra"
+)
+
+// fileCmd represents the file command
+var fileCmd = &cobra.Command{
+	Use:   "file",
+	Short: "Convert an audio file to text.",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+			return err
+		}
+
+		if _, err := os.Open(args[0]); err != nil {
+			return err
+		}
+
+		extension := filepath.Ext(args[0])
+		if extension != ".mp3" && extension != ".wav" {
+			return fmt.Errorf("only mp3 and wav files are supported")
+		}
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, closer := ui.LoadContext(cmd.Context())
+		text, err := service.SendAudio(ctx, args[0], cmd.Flag("lang").Value.String())
+		closer()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Println("---\n\n", text, "\n\n---")
+		if ui.YesNoPrompt("Copy to clipboard?") {
+			clipboard.WriteAll(text)
+		}
+	},
+}
+
+func init() {
+	speechCmd.AddCommand(fileCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// fileCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// fileCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -1,0 +1,41 @@
+//go:build portaudio
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MohammadBnei/go-openai-cli/service"
+	"github.com/spf13/cobra"
+)
+
+// recordCmd represents the record command
+var recordCmd = &cobra.Command{
+	Use:   "record",
+	Short: "Record audio to file",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := service.RecordAudioToFile(4*time.Minute, false, cmd.Flag("file").Value.String()); err != nil {
+			fmt.Println(err)
+			return
+		}
+		fmt.Printf("%s.wav saved\n", cmd.Flag("file").Value.String())
+	},
+}
+
+func init() {
+	speechCmd.AddCommand(recordCmd)
+
+	recordCmd.Flags().StringP("file", "f", "", "name of the file (without extension)")
+	recordCmd.MarkFlagRequired("file")
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// recordCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// recordCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/speech.go
+++ b/cmd/speech.go
@@ -75,7 +75,7 @@ var speechCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(speechCmd)
 
-	speechCmd.Flags().StringP("lang", "l", "en", "language")
+	speechCmd.PersistentFlags().StringP("lang", "l", "en", "language")
 	speechCmd.Flags().BoolVarP(&format, "format", "f", false, "format the output with the carriage return character.")
 	speechCmd.Flags().StringVarP(&advancedFormating, "advanced-format", "a", "add markdown formating. Add a title and a table of content from the content of the speech, and add the coresponding subtitles. Do not modify the content of the speech", "Add advanced formating that will be sent as system command to openai")
 	speechCmd.Flags().BoolVarP(&markdownMode, "markdown", "m", false, "Format the output to markdown")

--- a/ui/file.go
+++ b/ui/file.go
@@ -167,11 +167,8 @@ func AddToFile(content []byte, filename string) error {
 			return err
 		}
 		content = append([]byte("\n\n"), content...)
-		fmt.Println(fileContent)
 		content = append(fileContent, content...)
 	}
-
-	fmt.Println(string(content))
 
 	os.WriteFile(filename, content, os.ModePerm)
 

--- a/ui/speech.go
+++ b/ui/speech.go
@@ -57,7 +57,7 @@ func SpeechLoop(ctx context.Context, cfg *SpeechConfig) error {
 		}
 	}()
 
-	ctx1, closer := loadContext(ctx)
+	ctx1, closer := LoadContext(ctx)
 	speech, err := service.SpeechToText(ctx1, cfg.Lang, time.Duration(cfg.MaxMinutes)*time.Minute, false)
 	closer()
 	if err != nil {
@@ -82,7 +82,7 @@ func SpeechLoop(ctx context.Context, cfg *SpeechConfig) error {
 			writer = markdown.NewMarkdownWriter()
 		}
 		fmt.Print("Formating with openai : \n---\n\n")
-		ctx1, closer := loadContext(ctx)
+		ctx1, closer := LoadContext(ctx)
 		text, err := service.SendPrompt(ctx1, speech, writer)
 		closer()
 		if cfg.MarkdownMode {
@@ -116,7 +116,7 @@ func SpeechLoop(ctx context.Context, cfg *SpeechConfig) error {
 			fmt.Println("Specify the filename orally. If you don't want to specify, press enter twice.")
 			fmt.Println("Press enter to record")
 			fmt.Scanln()
-			ctx1, closer := loadContext(ctx)
+			ctx1, closer := LoadContext(ctx)
 			filename, err = service.SpeechToText(ctx1, cfg.Lang, 3*time.Second, false)
 			closer()
 			filename = strings.TrimSpace(filename)
@@ -143,7 +143,7 @@ func SpeechLoop(ctx context.Context, cfg *SpeechConfig) error {
 	return nil
 }
 
-func loadContext(ctx context.Context) (context.Context, func()) {
+func LoadContext(ctx context.Context) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(ctx)
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)

--- a/ui/speech.go
+++ b/ui/speech.go
@@ -1,0 +1,160 @@
+//go:build portaudio
+
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/MohammadBnei/go-openai-cli/markdown"
+	"github.com/MohammadBnei/go-openai-cli/service"
+	"github.com/atotto/clipboard"
+	"github.com/manifoldco/promptui"
+	"github.com/samber/lo"
+	"github.com/sashabaranov/go-openai"
+)
+
+type SpeechConfig struct {
+	MaxMinutes   int
+	Lang         string
+	AutoMode     bool
+	AutoFilename string
+	MarkdownMode bool
+	Format       bool
+}
+
+func SpeechLoop(ctx context.Context, cfg *SpeechConfig) error {
+	done := atomic.Bool{}
+	done.Store(false)
+	defer func(done *atomic.Bool) {
+		done.Store(true)
+	}(&done)
+
+	fmt.Println("Press enter to start")
+	fmt.Scanln()
+	go func() {
+		time.Sleep(time.Duration(cfg.MaxMinutes)*time.Minute - 15*time.Second)
+		if done.Load() {
+			return
+		}
+		if done.Load() {
+			return
+		}
+		fmt.Print("15 seconds remaining...")
+		time.Sleep(10 * time.Second)
+		for i := 5; i > 0; i-- {
+			if done.Load() {
+				return
+			}
+			fmt.Printf("%d seconds remaining...", i)
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	ctx1, closer := loadContext(ctx)
+	speech, err := service.SpeechToText(ctx1, cfg.Lang, time.Duration(cfg.MaxMinutes)*time.Minute, false)
+	closer()
+	if err != nil {
+		return err
+	}
+
+	fmt.Print("\n---\n", speech, "\n---\n\n")
+
+	if cfg.AutoMode {
+		err := AddToFile([]byte(speech), cfg.AutoFilename)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if lo.SomeBy[service.ChatMessage](service.GetMessages(), func(m service.ChatMessage) bool {
+		return m.Role == openai.ChatMessageRoleSystem
+	}) {
+		var writer io.Writer = os.Stdout
+		if cfg.MarkdownMode {
+			writer = markdown.NewMarkdownWriter()
+		}
+		fmt.Print("Formating with openai : \n---\n\n")
+		ctx1, closer := loadContext(ctx)
+		text, err := service.SendPrompt(ctx1, speech, writer)
+		closer()
+		if cfg.MarkdownMode {
+			writer.(*markdown.MarkdownWriter).Flush(text)
+		}
+		if err != nil {
+			return err
+		} else {
+			speech = text
+		}
+		fmt.Print("\n\n---\n\n")
+	}
+
+	selectionPrompt := promptui.Select{
+		Label: "Speech converted to text. What do you want to do with it ?",
+		Items: []string{"Copy to clipboard", "Save in file", "another speech", "quit"},
+	}
+
+	id, _, err := selectionPrompt.Run()
+	if err != nil {
+		return err
+	}
+
+	switch id {
+	case 0:
+		clipboard.WriteAll(speech)
+	case 1:
+		filename := ""
+	filenameLoop:
+		for {
+			fmt.Println("Specify the filename orally. If you don't want to specify, press enter twice.")
+			fmt.Println("Press enter to record")
+			fmt.Scanln()
+			ctx1, closer := loadContext(ctx)
+			filename, err = service.SpeechToText(ctx1, cfg.Lang, 3*time.Second, false)
+			closer()
+			filename = strings.TrimSpace(filename)
+			fmt.Printf(" Filename : '%s'\n", filename)
+			switch {
+			case err != nil:
+				fmt.Println(err)
+				continue filenameLoop
+			case filename == "":
+				break filenameLoop
+			case YesNoPrompt(fmt.Sprintf("Filename : %s", filename)):
+				break filenameLoop
+			}
+		}
+		SaveToFile([]byte(speech), filename)
+	case 2:
+		return nil
+	case 3:
+		os.Exit(0)
+	}
+
+	fmt.Print("\n✅\n\n")
+
+	return nil
+}
+
+func loadContext(ctx context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(ctx)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		_, ok := <-c
+		if ok {
+			cancel()
+		}
+	}()
+	return ctx, func() {
+		signal.Stop(c)
+		close(c)
+	}
+}


### PR DESCRIPTION
- chore(root.go): remove duplicate banner print statement feat(root.go): add PersistentPreRun function to print banner before command execution
- completion
- completion
- fix(banner): put banner message in command Run instead of root, because it corrupted the completion output
- refactor(file.go): remove unnecessary print statements The print statements that were used for debugging purposes have been removed to improve code cleanliness and remove unnecessary output.
- refactor(speech): refactored speech cmd into the ui package
- feat(cmd/file.go): add new 'file' command to convert an audio file to text
- feat(cmd/record.go): add 'record' command to the 'speech' command group
- fix(speech.go): change function name from loadContext to LoadContext to follow Go naming conventions
- feat(audio.go): add SendAudio function to send the recorded audio file to OpenAI for transcription refactor(audio.go): change RecordAudioToFile function to accept a filename parameter for flexibility in naming the recorded audio file fix(audio.go): fix the file path in the CreateTranscription request to use the provided filename parameter instead of hardcoding "speech.wav"
- refactor(speech.go): change flag registration from speechCmd.Flags() to speechCmd.PersistentFlags() to make the flag persistent across subcommands feat(speech.go): add new flag 'advanced-format' to enable advanced formatting options for the speech output feat(speech.go): add new flag 'markdown' to enable formatting the output as markdown
